### PR TITLE
Replace old API versions by latest

### DIFF
--- a/getting-started/controllers/request-and-response-objects.md
+++ b/getting-started/controllers/request-and-response-objects.md
@@ -4,9 +4,9 @@ Request and Response objects are available to the controller as `request and res
 
 ### The Request Object and Controller Helper Methods
 
-It serves both to perform requests by an [`HTTP::Client`](https://crystal-lang.org/api/0.23.0/HTTP/Client.html)and to represent requests received by an[`HTTP::Server`](https://crystal-lang.org/api/0.23.0/HTTP/Server.html). A request always holds an [`IO`](https://crystal-lang.org/api/0.23.0/IO.html) as a body. When creating a request with a [`String`](https://crystal-lang.org/api/0.23.0/String.html) or [`Bytes`](https://crystal-lang.org/api/0.23.0/Bytes.html) its body will be a [`IO::Memory`](https://crystal-lang.org/api/0.23.0/IO/Memory.html) wrapping these, and the `Content-Length`header will be set appropriately.
+It serves both to perform requests by an [`HTTP::Client`](https://crystal-lang.org/api/latest/HTTP/Client.html)and to represent requests received by an[`HTTP::Server`](https://crystal-lang.org/api/latest/HTTP/Server.html). A request always holds an [`IO`](https://crystal-lang.org/api/latest/IO.html) as a body. When creating a request with a [`String`](https://crystal-lang.org/api/latest/String.html) or [`Bytes`](https://crystal-lang.org/api/latest/Bytes.html) its body will be a [`IO::Memory`](https://crystal-lang.org/api/latest/IO/Memory.html) wrapping these, and the `Content-Length`header will be set appropriately.
 
-The request object contains a lot of useful information about the request coming in from the client. To get a full list of the available methods, refer to the Crystal  API Documentation [https://crystal-lang.org/api/0.23.0/HTTP/Request.html](https://crystal-lang.org/api/0.23.0/HTTP/Request.html)
+The request object contains a lot of useful information about the request coming in from the client. To get a full list of the available methods, refer to the Crystal  API Documentation [https://crystal-lang.org/api/latest/HTTP/Request.html](https://crystal-lang.org/api/latest/HTTP/Request.html)
 
 | Helper Methods | Purpose | Implemented? |
 | :--- | :--- | :--- |
@@ -26,7 +26,7 @@ The request object contains a lot of useful information about the request coming
 
 ### The Response Object
 
-The response object is not usually used directly, but is built up during the execution of the action and rendering of the data that is being sent back to the user, but sometimes - like in an after filter - it can be useful to access the response directly. Some of these accessor methods also have setters, allowing you to change their values. To get a full list of the available methods, refer to the [https://crystal-lang.org/api/0.23.0/HTTP/Server/Response.html](https://crystal-lang.org/api/0.23.0/HTTP/Server/Response.html)
+The response object is not usually used directly, but is built up during the execution of the action and rendering of the data that is being sent back to the user, but sometimes - like in an after filter - it can be useful to access the response directly. Some of these accessor methods also have setters, allowing you to change their values. To get a full list of the available methods, refer to the [https://crystal-lang.org/api/latest/HTTP/Server/Response.html](https://crystal-lang.org/api/latest/HTTP/Server/Response.html)
 
 | Properties | Purpose |
 | :--- | :--- |

--- a/getting-started/routing/README.md
+++ b/getting-started/routing/README.md
@@ -4,7 +4,7 @@ The Amber router recognizes URLs and dispatches them to a controller's action. I
 
 ## [Pipelines](/routing/pipelines.md)
 
-A _pipeline_ is a set of of transformations that is performed to a HTTP request. These transformations come in the form of a pipe. A _pipe_ is a** **class which includes [`HTTP::Handler`](https://crystal-lang.org/api/0.22.0/HTTP/Handler.html) and implements the [`#call`](https://crystal-lang.org/api/0.22.0/HTTP/Handler.html#call%28context%3AHTTP%3A%3AServer%3A%3AContext%29-instance-method) method. You can use a handler to intercept any incoming request and modify the response. These can be used for request throttling, ip-based whitelisting, adding custom headers.
+A _pipeline_ is a set of of transformations that is performed to a HTTP request. These transformations come in the form of a pipe. A _pipe_ is a** **class which includes [`HTTP::Handler`](https://crystal-lang.org/api/latest/HTTP/Handler.html) and implements the [`#call`](https://crystal-lang.org/api/latest/HTTP/Handler.html#call%28context%3AHTTP%3A%3AServer%3A%3AContext%29-instance-method) method. You can use a handler to intercept any incoming request and modify the response. These can be used for request throttling, ip-based whitelisting, adding custom headers.
 
 ## [Routes](/getting-started/routing/routes.md)
 

--- a/getting-started/routing/pipelines.md
+++ b/getting-started/routing/pipelines.md
@@ -1,6 +1,6 @@
 # Pipelines
 
-A _pipeline_ is a set of of transformations that is performed to a HTTP request. These transformations come in the form of a pipe. A _pipe_ is a class which includes [`HTTP::Handler`](https://crystal-lang.org/api/0.22.0/HTTP/Handler.html) and implements the [`#call`](https://crystal-lang.org/api/0.22.0/HTTP/Handler.html#call%28context%3AHTTP%3A%3AServer%3A%3AContext%29-instance-method) method. 
+A _pipeline_ is a set of of transformations that is performed to a HTTP request. These transformations come in the form of a pipe. A _pipe_ is a class which includes [`HTTP::Handler`](https://crystal-lang.org/api/latest/HTTP/Handler.html) and implements the [`#call`](https://crystal-lang.org/api/latest/HTTP/Handler.html#call%28context%3AHTTP%3A%3AServer%3A%3AContext%29-instance-method) method. 
 
 You can use a handler to intercept any incoming request and modify the response. These can be used for request throttling, ip-based whitelisting, adding custom headers.
 
@@ -36,7 +36,7 @@ Amber::Server.instance.config do |app|
 end
 ```
 
-Above we define a pipeline called `:web` as you can see the `:web` pipeline transforms the request using a _Logger_, _StaticFileHandler_ and a _CompressHandler_, all of which extends from the Crystal [_HTTP::Handler_](https://crystal-lang.org/api/0.22.0/HTTP/Handler.html) class.
+Above we define a pipeline called `:web` as you can see the `:web` pipeline transforms the request using a _Logger_, _StaticFileHandler_ and a _CompressHandler_, all of which extends from the Crystal [_HTTP::Handler_](https://crystal-lang.org/api/latest/HTTP/Handler.html) class.
 
 Amber provides us some default pipes for a number of common tasks. In turn we can customize them as well as create new pipelines to meet our needs.
 

--- a/getting-started/views/README.md
+++ b/getting-started/views/README.md
@@ -14,7 +14,7 @@ For information on how to use Slang,[ https://github.com/jeromegn/slang](https:/
 
 ## ECR \(Embedded Crystal\)
 
-For a primer on ECR please see [https://crystal-lang.org/api/0.22.0/ECR.html](https://crystal-lang.org/api/0.22.0/ECR.html)
+For a primer on ECR please see [https://crystal-lang.org/api/latest/ECR.html](https://crystal-lang.org/api/latest/ECR.html)
 
 # Render method
 


### PR DESCRIPTION
We should keep using the latest version of crystal API, this PR fix that. :smile: 