### PR TITLE
Fix grammar and spelling in `create-new-app.md`

### DIFF
--- a/getting-started/Installation/create-new-app.md
+++ b/getting-started/Installation/create-new-app.md
@@ -95,7 +95,7 @@ By default Amber accepts requests on port 3000. If we point our favorite web bro
 
 If your screen looks like the image above, congratulations! You now have a working Amber application. If you don’t see the page above, try accessing it via [http://127.0.0.1:3000](http://127.0.0.1:3000) and later make sure your OS has defined “localhost” as “127.0.0.1”.
 
-Locally, the application is running in an Crystal process. To stop it, we hit ctrl-c once, just as we would to terminate the pragram normally.
+Locally, the application is running in a Crystal process. To stop it, we hit ctrl-c once, just as we would to terminate the program normally.
 
 > **Note:** The **amber watch** command uses [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically. If you don't want to use Sentry, you can compile and run manually:  
 > 1. Build the app `crystal build --release src/[your_app].cr`  

--- a/getting-started/views/README.md
+++ b/getting-started/views/README.md
@@ -1,10 +1,10 @@
 # Views
 
-Views are rendered using the amber `render` macro, which uses .  Currently amber
+Views are rendered using the amber `render` macro, which uses [Kilt](http://github.com/jeromegn/kilt). Currently amber
 there are 4 different templating languages supported by Kilt: `slang` `ecr`, `mustache`,
-and `temel`.  Behind the scenes [Kilt](http://github.com/jeromegn/kilt) selects the templating engine based on the
+and `temel`. Behind the scenes [Kilt](http://github.com/jeromegn/kilt) selects the templating engine based on the
 extension of the file so `index.ecr` will render the file using the ECR
-engine. Amber is currently supports `slang` and `ecr`. Kilt will work with `mustache`
+engine. Amber currently supports `slang` and `ecr`. Kilt will work with `mustache`
 and `temel` as well, although they haven't been tested in amber.  
 
 The Amber Generators support `slang` and `ecr` templates using the `-t` option when you create a new project.


### PR DESCRIPTION
This is not a full grammar review of the docs. These just stuck out as I was using the guide.