### PR TITLE
Added libyaml-dev to ubuntu/debian requirements.

### DIFF
--- a/getting-started/Installation/README.md
+++ b/getting-started/Installation/README.md
@@ -28,7 +28,7 @@ make install
 
 ##### For Debian & Ubuntu
 - These are necessary to compile the CLI:
-- `sudo apt-get install build-essential libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev`
+- `sudo apt-get install build-essential libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev libyaml-dev`
 
 ##### For RedHat & CentOS
 - `sudo yum groupinstall development tools`


### PR DESCRIPTION
The CLI would compile using `make install` but wouldn't run. Installing `libyaml-dev` and re-compiling fixed this.