### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: crystal


### PR DESCRIPTION
Fixes Travis error: Could not find .travis.yml, using standard configuration.