### PR TITLE
Add documentation for debugging projects

### DIFF
--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -1,6 +1,6 @@
 # Debugging Crystal Projects using VSCode
 
-This tutorial have some tips and tricks to debug Crystal projects with tools like GDB or LLDB using debugger clients like [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) for VSCode.
+This tutorial has tips and tricks on how to debug Crystal projects. It shows how to leverage tools like GDB or LLDB using debugger clients like [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) for VSCode.
 
 ## Prerequisites
 
@@ -9,7 +9,7 @@ This tutorial have some tips and tricks to debug Crystal projects with tools lik
 * VSCode with [Crystal Lang](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) and [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) extensions
 * GNU debugger (GDB) or LLVM debugger (LLDB) - See installation guide below
 
-To install GDB or LLDB according with your OS use one of the following commands:
+Install GDB or LLDB based commands below for your OS.
 
 ##### MacOS
 
@@ -28,11 +28,11 @@ To install GDB or LLDB according with your OS use one of the following commands:
 `pacman -S gdb lldb`
 
 
-> Note: Before continuing setting up the debugger make sure you have the above prerequisites installed. These settings have been verified for a MacOS and Linux's enviroments
+> Note: Confirm that the above prerequisites are installed before setting up the debugger. These settings have been verified for a MacOS and Linux's environments.
 
 ## Steps
 
-> By convention project directory name is equal to your application name, if you have changed it, please update `${workspaceFolderBasename}` by your prefered name configured inside `shards.yml`
+> By convention the project directory name is the same as your application name, if you have changed it, please update ${workspaceFolderBasename} with the name configured inside shards.yml
 
 ### 1. `task.json` configuration to compile a crystal project
 
@@ -91,11 +91,11 @@ To install GDB or LLDB according with your OS use one of the following commands:
 
 ![debugging](https://i.imgur.com/GsGT1h0.png)
 
-## Trips and Tricks for debugging Crystal applications
+## TTips and Tricks for debugging Crystal applications
 
-> DISCLAIMER: LLDB doesn't show variables data for crystal applications yet, see [issue #4457](https://github.com/crystal-lang/crystal/issues/4457).
+> DISCLAIMER: LLDB does not show variable data for crystal applications yet, see [issue #4457](https://github.com/crystal-lang/crystal/issues/4457).
 
-Actually debugging Crystal application is not fully supported yet. However you can use some techniques to improve your debugging experience.
+Fully debugging Crystal applications is not supported yet. You can use some of the techniques below to improve the debugging experience.
 
 ### 1. Use debugger keyword
 
@@ -111,9 +111,9 @@ end
 
 ### 2. Avoid breakpoints inside blocks
 
-Currently crystal lacks of some debugging info, making blocks hard to debug, so if you try to put a breakpoint inside a block, it will be ignored.
+Currently, Crystal lacks support for debugging inside of blocks. If you put a breakpoint inside a block, it will be ignored.
 
-Alternatively, you can try `pp` to pretty print objects.
+As a workaround, use `pp` to pretty print objects inside of blocks.
 
 ```crystal
 3.times do |i|
@@ -126,7 +126,7 @@ end
 
 ### 3. Try `@[NoInline]` to debug arguments data
 
-Sometimes crystal optimize arguments data, so the debugger will shows args like `<optimized output>`. To avoid this behaivior use `@[NoInline]` attribute before your function implementation.
+Sometimes crystal will optimize argument data, so the debugger will show `<optimized output>` instead of the arguments. To avoid this behavior use the `@[NoInline]` attribute before your function implementation.
 
 ```crystal
 @[NoInline]
@@ -137,41 +137,45 @@ end
 
 ### 4. Printing strings objects (GDB)
 
-To print string objects like:
+To print string objects in the debugger:
+
+First, setup the debugger with the `debugger` statement:
 
 ```crystal
 foo = "Hello World!"
 debugger
 ```
 
-Use `print` in debugging console:
+Then use `print` in the debugging console.
 
 ```sh
 (gdb) print &foo.c
 $1 = (UInt8 *) 0x10008e6c4 "Hello World!"
 ```
 
-Or adding `&foo.c` using a new variable entry on watch section in VSCode debugger
+Or add `&foo.c` using a new variable entry on watch section in VSCode debugger
 
-![watch](https://i.imgur.com/EpQinL7.png)
+![watch](https://i.imgur.com/EpQinL7.png "Using VSCode GUI")
 
 ### 5. Printing array variables
 
-To print array items like:
+To print array items in the debugger:
+
+First, setup the debugger with the `debugger` statement:
 
 ```crystal
 foo = ["item 0", "item 1", "item 2"]
 debugger
 ```
 
-Try in your debugger this command:
+Then use `print` in the debugging console:
 
 ```
 (gdb) print &foo.buffer[0].c
 $19 = (UInt8 *) 0x10008e7f4 "item 0"
 ```
 
-Changing the buffer index for each item.
+Change the buffer index for each item you want to print.
 
 
 ### 6. Printing instance variables
@@ -189,11 +193,11 @@ end
 Bar.new
 ```
 
-You can use `self.foo` in debugger terminal or VSCode GUI.
+You can use `self.foo` in the debugger terminal or VSCode GUI.
 
 ### 7. Print hidden objects
 
-Some objects doesn't show at all. So you can unhide them by using `.to_s` method and an auxiliar variable, like this:
+Some objects do not show at all. You can unhide them using the `.to_s` method and a temporary debugging variable, like this:
 
 ```crystal
 def bar(hello)
@@ -201,11 +205,11 @@ def bar(hello)
 end
 
 def foo(hello)
-  auxiliar = bar(hello).to_s
+  bar_hello_to_s = bar(hello).to_s
   debugger
 end
 
 foo("Hello")
 ```
 
-This trick allows to show auxiliar variable inside debugger tool.
+This trick allows showing the `bar_hello_to_s` variable inside the debugger tool.

--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -1,15 +1,15 @@
-# Debugging Crystal Projects
+# Debugging Crystal Projects using VSCode
 
 This tutorial have some tips and tricks to debug Crystal projects with tools like GDB or LLDB using debugger clients like [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) for VSCode.
 
-## Requisites
+## Prerequisites
 
 * Crystal - See instalation guide [here](https://crystal-lang.org/docs/installation/)
-* Amber Project - See installation guide [here](/getting-started/Installation/README.md)
-* GNU Debugger (GDB) or LLVM Debugger (LLDB)
-* VSCode + [Crystal Support](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) + [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug)
+* Crystal project - See installation guide [here](https://crystal-lang.org/docs/using_the_compiler/#creating-a-project-or-library) or [here (Amber)](/getting-started/Installation/README.md)
+* VSCode with [Crystal Lang](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) and [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) extensions
+* GNU debugger (GDB) or LLVM debugger (LLDB) - See installation guide below
 
-To install GDB and LLDB according with your OS use one of the following commands:
+To install GDB or LLDB according with your OS use one of the following commands:
 
 ##### MacOS
 
@@ -28,9 +28,11 @@ To install GDB and LLDB according with your OS use one of the following commands
 `pacman -S gdb lldb`
 
 
-> Note: Before continuing setting up the debugger make sure you have the above requisites install. These settings have been verified for a MacOS and Linux's enviroments
+> Note: Before continuing setting up the debugger make sure you have the above prerequisites installed. These settings have been verified for a MacOS and Linux's enviroments
 
 ## Steps
+
+> By convention project directory name is equal to your application name, if you have changed it, please update `${workspaceFolderBasename}` by your prefered name configured inside `shards.yml`
 
 ### 1. `task.json` configuration to compile a crystal project
 

--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -109,7 +109,7 @@ end
 
 ### 2. Avoid breakpoints inside blocks
 
-Currently crystal lacks of some debugging info, making blocks hard to debug, so if you try to put a breakpoint inside a block, it would be almost ignored.
+Currently crystal lacks of some debugging info, making blocks hard to debug, so if you try to put a breakpoint inside a block, it will be ignored.
 
 Alternatively, you can try `pp` to pretty print objects.
 

--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -1,40 +1,55 @@
-# VS Code Amber Debug
+# Debugging Crystal Projects
 
-Debugging an Amber project on VSCode with GDB and [Native Debug](https://github.com/crystal-lang-tools/vscode-crystal-lang/wiki/Useful-extensions#debugging).
+This tutorial have some tips and tricks to debug Crystal projects with tools like GDB or LLDB using debugger clients like [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) for VSCode.
 
 ## Requisites
 
-* Crystal
+* Crystal - See instalation guide [here](https://crystal-lang.org/docs/installation/)
 * Amber Project - See installation guide [here](/getting-started/Installation/README.md)
-* GNU Debugger (GDB) - MacOS install `brew install gdb`
-* VSCode + [Crystal Support](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) + [Native Debug](https://github.com/WebFreak001/code-debug)
+* GNU Debugger (GDB) or LLVM Debugger (LLDB)
+* VSCode + [Crystal Support](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) + [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug)
 
-> Note: Before continuing setting up the debugger make sure you have the above requisites install. These settings have been verified for a MacOS enviroment.
+To install GDB and LLDB according with your OS use one of the following commands:
+
+##### MacOS
+
+`brew install gdb lldb`
+
+##### Ubuntu
+
+`apt install gdb lldb`
+
+##### Fedora
+
+`dnf install gdb lldb`
+
+##### ArchLinux
+
+`pacman -S gdb lldb`
+
+
+> Note: Before continuing setting up the debugger make sure you have the above requisites install. These settings have been verified for a MacOS and Linux's enviroments
 
 ## Steps
 
-**1. `task.json` to compile the main file with debug support**
+### 1. `task.json` configuration to compile a crystal project
 
 ```json
 {
   "version": "2.0.0",
   "tasks": [
     {
-      "taskName": "amber",
-      "command": "crystal build -d -p src/{project file}.cr -o app",
-      "type": "shell",
-      "presentation": {
-        "echo": true,
-        "reveal": "never",
-        "focus": false,
-        "panel": "shared"
-      }
+      "label": "Compile",
+      "command": "shards build --debug ${workspaceFolderBasename}",
+      "type": "shell"
     }
   ]
-}
+      }
 ```
 
-**2.`launch.json` configuration to debug binary**
+### 2. `launch.json` configuration to debug a binary
+
+#### Using GDB
 
 ```json
 {
@@ -44,15 +59,35 @@ Debugging an Amber project on VSCode with GDB and [Native Debug](https://github.
       "name": "Debug",
       "type": "gdb",
       "request": "launch",
-      "target": "./app",
+      "target": "./bin/${workspaceFolderBasename}",
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": "amber"
+      "preLaunchTask": "Compile"
     }
   ]
 }
 ```
 
-**3. Then hit the green play button**
+#### Using LLDB
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug",
+      "type": "lldb-mi",
+      "request": "launch",
+      "target": "./bin/${workspaceFolderBasename}",
+      "cwd": "${workspaceRoot}",
+      "preLaunchTask": "Compile"
+    }
+  ]
+}
+```
+
+### 3. Then hit the DEBUG green play button
+
+![debugging](https://i.imgur.com/GsGT1h0.png)
 
 ![green button](https://camo.githubusercontent.com/30adba87add4770abf2c3982206748123f8a2c6e/687474703a2f2f692e696d6775722e636f6d2f6d674b41366d782e706e67)
 

--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -91,9 +91,9 @@ Install GDB or LLDB based commands below for your OS.
 
 ![debugging](https://i.imgur.com/GsGT1h0.png)
 
-## TTips and Tricks for debugging Crystal applications
+## Tips and Tricks for debugging Crystal applications
 
-> DISCLAIMER: LLDB does not show variable data for crystal applications yet, see [issue #4457](https://github.com/crystal-lang/crystal/issues/4457).
+> DISCLAIMER: LLDB does not show data for variables in crystal applications yet, see [issue #4457](https://github.com/crystal-lang/crystal/issues/4457).
 
 Fully debugging Crystal applications is not supported yet. You can use some of the techniques below to improve the debugging experience.
 

--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -102,8 +102,8 @@ Instead of putting breakpoints using commands inside GDB or LLDB you can try to 
 ```crystal
 i = 0
 while i < 3
-  debugger # => breakpoint
   i += 1
+  debugger # => breakpoint
 end
 ```
 

--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -191,7 +191,7 @@ You can use `self.foo` in debugger terminal or VSCode GUI.
 
 ### 7. Print hidden objects
 
-Some objects doen't show at all. So you can unhide them by using `.to_s` method and an auxiliar variable, like this:
+Some objects doesn't show at all. So you can unhide them by using `.to_s` method and an auxiliar variable, like this:
 
 ```crystal
 def bar(hello)

--- a/recipes/debugging/vs-code-debug.md
+++ b/recipes/debugging/vs-code-debug.md
@@ -44,7 +44,7 @@ To install GDB and LLDB according with your OS use one of the following commands
       "type": "shell"
     }
   ]
-      }
+}
 ```
 
 ### 2. `launch.json` configuration to debug a binary
@@ -89,11 +89,121 @@ To install GDB and LLDB according with your OS use one of the following commands
 
 ![debugging](https://i.imgur.com/GsGT1h0.png)
 
-![green button](https://camo.githubusercontent.com/30adba87add4770abf2c3982206748123f8a2c6e/687474703a2f2f692e696d6775722e636f6d2f6d674b41366d782e706e67)
+## Trips and Tricks for debugging Crystal applications
 
-![change variable value](https://camo.githubusercontent.com/c5a551366c3eb2464c920bf3f95e8cdfb97ad827/687474703a2f2f692e696d6775722e636f6d2f6b506b546e75442e706e67)
+> DISCLAIMER: LLDB doesn't show variables data for crystal applications yet, see [issue #4457](https://github.com/crystal-lang/crystal/issues/4457).
 
-[Native Debug](https://github.com/WebFreak001/code-debug) allows to set breakpoints, watch variables and execute GDB commands inside VSCode.
+Actually debugging Crystal application is not fully supported yet. However you can use some techniques to improve your debugging experience.
+
+### 1. Use debugger keyword
+
+Instead of putting breakpoints using commands inside GDB or LLDB you can try to set a breakpoint using `debugger` keyword.
+
+```crystal
+i = 0
+while i < 3
+  debugger # => breakpoint
+  i += 1
+end
+```
+
+### 2. Avoid breakpoints inside blocks
+
+Currently crystal lacks of some debugging info, making blocks hard to debug, so if you try to put a breakpoint inside a block, it would be almost ignored.
+
+Alternatively, you can try `pp` to pretty print objects.
+
+```crystal
+3.times do |i|
+  pp i
+end
+# i => 1
+# i => 2
+# i => 3
+```
+
+### 3. Try `@[NoInline]` to debug arguments data
+
+Sometimes crystal optimize arguments data, so the debugger will shows args like `<optimized output>`. To avoid this behaivior use `@[NoInline]` attribute before your function implementation.
+
+```crystal
+@[NoInline]
+def foo(bar)
+  debugger
+end
+```
+
+### 4. Printing strings objects (GDB)
+
+To print string objects like:
+
+```crystal
+foo = "Hello World!"
+debugger
+```
+
+Use `print` in debugging console:
+
+```sh
+(gdb) print &foo.c
+$1 = (UInt8 *) 0x10008e6c4 "Hello World!"
+```
+
+Or adding `&foo.c` using a new variable entry on watch section in VSCode debugger
+
+![watch](https://i.imgur.com/EpQinL7.png)
+
+### 5. Printing array variables
+
+To print array items like:
+
+```crystal
+foo = ["item 0", "item 1", "item 2"]
+debugger
+```
+
+Try in your debugger this command:
+
+```
+(gdb) print &foo.buffer[0].c
+$19 = (UInt8 *) 0x10008e7f4 "item 0"
+```
+
+Changing the buffer index for each item.
 
 
+### 6. Printing instance variables
 
+For printing `@foo` var in this code:
+
+```crystal
+class Bar
+  @foo = 0
+  def baz
+    debugger
+  end
+end
+
+Bar.new
+```
+
+You can use `self.foo` in debugger terminal or VSCode GUI.
+
+### 7. Print hidden objects
+
+Some objects doen't show at all. So you can unhide them by using `.to_s` method and an auxiliar variable, like this:
+
+```crystal
+def bar(hello)
+  "#{hello} World!"
+end
+
+def foo(hello)
+  auxiliar = bar(hello).to_s
+  debugger
+end
+
+foo("Hello")
+```
+
+This trick allows to show auxiliar variable inside debugger tool.


### PR DESCRIPTION
This PR:

- Updates current debugging guide (images and content)
- Adds tips and tricks for debugging (based on [Debugging with GDB](https://stackoverflow.com/questions/46369703/crystal-debugging-with-gdb/46567329#46567329))