### PR TITLE
Use double quotes

### DIFF
--- a/getting-started/routing/routes.md
+++ b/getting-started/routing/routes.md
@@ -127,7 +127,7 @@ routes :web do
 end
 
 # Scoped
-routes :web, '/admin' do
+routes :web, "/admin" do
   resources "/posts", AdminPostsController
 end
 ```


### PR DESCRIPTION
Double quotes should be used for strings, otherwise it throws an error.